### PR TITLE
Fix build fail on Windows due to C++11 usage

### DIFF
--- a/src/frange.cpp
+++ b/src/frange.cpp
@@ -48,7 +48,7 @@ double abs_max_(const NumericVector& x, const bool finite = true) {
   for(int i = 0; i < n; ++i) {
     double xi = x[i];
     if (!finite) {
-      if (isnan(xi)) return NA_REAL;
+      if (ISNAN(xi)) return NA_REAL;
       if (xi == INFINITY) return INFINITY;
       if (xi == -INFINITY) return INFINITY;
     }


### PR DESCRIPTION
ggstat does not compile on Windows with R 3.3.0 and Rtools 3.3, because `isnan` in frange.cpp is C++11, and that does not seem to work (it returns the error `'isnan' was not declared in this scope`). Build on Ubuntu however runs without problems. I changed `isnan` to `ISNAN` as in Group-1d.h
